### PR TITLE
fix: change hover color of the footer text and icons to fix the contrast

### DIFF
--- a/components/footer.jsx
+++ b/components/footer.jsx
@@ -34,7 +34,7 @@ export default function Footer() {
           <div>
             <div className="flex flex-wrap w-full -mt-2 -ml-3 lg:ml-0">
               {navigation.map((item, index) => (
-                <Link key={index} href={item.href} className="w-full px-4 py-2 text-gray-500 rounded-md  hover:text-[#f1e37e] focus:bg-[#f9f4d1] focus:outline-none">                 
+                <Link key={index} href={item.href} className="w-full px-4 py-2 text-gray-500 rounded-md  hover:text-[#1d272a] focus:bg-[#f9f4d1] focus:outline-none">                 
                     {item.label}
                 </Link>
               ))}
@@ -46,6 +46,7 @@ export default function Footer() {
               <a
                 href="https://www.facebook.com/institutolanternaluminosa"
                 target="_blank"
+                className="hover:text-green"
                 rel="noopener">
                 <span className="sr-only">Facebook</span>
                 <Facebook />
@@ -53,6 +54,7 @@ export default function Footer() {
               <a
                 href="https://www.instagram.com/institutolanternaluminosa/"
                 target="_blank"
+                className="hover:text-green"
                 rel="noopener">
                 <span className="sr-only">Instagram</span>
                 <Instagram />


### PR DESCRIPTION
Change hover color of the footer text and icons to fix the contrast. From yellow to green.